### PR TITLE
On_add-remove

### DIFF
--- a/examples/advanced/connect4/connect4/__main__.py
+++ b/examples/advanced/connect4/connect4/__main__.py
@@ -20,19 +20,26 @@ PLAYER_NAMES = "Red", "Yellow"
 class Connect4(Widget):
     def __init__(self):
         self._board = Board()
-        self._label = TextWidget(size=(1, 10), pos_hint=(None, .5), anchor="center")
-
         h, w = self._board.size
 
-        super().__init__(
-            size=(h + 2, w),
+        super().__init__(size=(h + 2, w),
             pos_hint=(.5, .5),
             anchor="center",
         )
 
+        self._label = TextWidget(size=(1, 10), pos_hint=(None, .5), anchor="center")
+        self.add_widgets(self._board, self._label)
+
+    def on_add(self):
+        super().on_add()
         self._animation_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
-        self._columns = [[]]
+        self._label_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
         self.reset()
+
+    def on_remove(self):
+        super().on_remove()
+        self._animation_task.cancel()
+        self._label_task.cancel()
 
     def display_message(self, message):
         self._label.width = len(message)
@@ -46,17 +53,14 @@ class Connect4(Widget):
     def reset(self):
         self._animation_task.cancel()
 
-        for column in self._columns:
-            for checker in column:
-                checker.stop_flash()
-
         self._columns = [[] for _ in range(7)]
         self._board_array = np.zeros((6, 7), dtype=int)
         self._game_over = False
         self._player = 0
 
-        self.children.clear()
-        self.add_widgets(self._label, self._board)
+        for child in self.children.copy():
+            if child not in {self._label, self._board}:
+                child.destroy()
 
         self.display_message(TURN_MESSAGE.format(self.current_player))
 
@@ -143,7 +147,7 @@ class Connect4(Widget):
 
             if (row := (5 - len(self._columns[col]))) == -1:
                 self.display_message(COLUMN_FULL_MESSAGE)
-                asyncio.create_task(
+                self._label_task = asyncio.create_task(
                     self.display_message_after(TURN_MESSAGE.format(self.current_player), 2)
                 )
                 return

--- a/examples/advanced/connect4/connect4/__main__.py
+++ b/examples/advanced/connect4/connect4/__main__.py
@@ -170,4 +170,4 @@ class Connect4(Widget):
             )
 
 
-run_widget_as_app(Connect4)
+run_widget_as_app(Connect4())

--- a/examples/advanced/connect4/connect4/graphics.py
+++ b/examples/advanced/connect4/connect4/graphics.py
@@ -45,16 +45,18 @@ class Checker(GraphicWidget):
     def __init__(self, color):
         super().__init__(size=CHECKER_SIZE)
 
-        self._flash_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
-
         h, w = self._size
         center = h, w // 2
         radius = w // 3
         cv2.circle(self.texture, center, radius, color, -1)
         self._color = color
 
+    def on_add(self):
+        super().on_add()
+        self._flash_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+
     def flash(self):
-        asyncio.create_task(self._flash())
+        self._flash_task = asyncio.create_task(self._flash())
 
     def stop_flash(self):
         self._flash_task.cancel()

--- a/examples/advanced/digital_clock.py
+++ b/examples/advanced/digital_clock.py
@@ -21,7 +21,13 @@ class DigitalClock(TextWidget):
 
         self.canvas[[2, -3], 16] = self.canvas[[2, -3], 34] = "●"
 
+    def on_add(self):
+        super().on_add()
         self._update_task = asyncio.create_task(self._update_time())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def _formatted_time(self):
         hours, minutes, seconds = time.localtime()[3: 6]

--- a/examples/advanced/doom_fire.py
+++ b/examples/advanced/doom_fire.py
@@ -68,7 +68,13 @@ class DoomFire(GraphicWidget):
         self._fire_values = np.zeros((2 * h, w), dtype=int)
         self.fire_strength = fire_strength
 
-        asyncio.create_task(self._step_forever())
+    def on_add(self):
+        super().on_add()
+        self._step_forever_task = asyncio.create_task(self._step_forever())
+
+    def on_remove(self):
+        super().on_remove()
+        self._step_forever_task.cancel()
 
     @property
     def fire_strength(self):

--- a/examples/advanced/game_of_life.py
+++ b/examples/advanced/game_of_life.py
@@ -75,4 +75,4 @@ class Life(GraphicWidget):
             self.texture[h - 1: h + 3, w - 1: w + 2, :3] = np.random.randint(0, 256, 3)
 
 
-run_widget_as_app(Life, size_hint=(1.0, 1.0))
+run_widget_as_app(Life(size_hint=(1.0, 1.0)))

--- a/examples/advanced/game_of_life.py
+++ b/examples/advanced/game_of_life.py
@@ -22,9 +22,13 @@ UPDATE_SPEED = .1
 
 
 class Life(GraphicWidget):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def on_add(self):
+        super().on_add()
         self._update_task = asyncio.create_task(self._update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def on_size(self):
         super().on_size()

--- a/examples/advanced/isotiles.py
+++ b/examples/advanced/isotiles.py
@@ -156,7 +156,7 @@ class IsoTileApp(App):
             show_horizontal_bar=False,
             mouse_button=MouseButton.MIDDLE,
         )
-        sv.add_widget(WorldWidget())
+        sv.view = WorldWidget()
         self.add_widget(sv)
 
 

--- a/examples/advanced/isotiles.py
+++ b/examples/advanced/isotiles.py
@@ -56,7 +56,13 @@ class WorldWidget(GraphicWidget):
 
         self.paint_world()
 
+    def on_add(self):
+        super().on_add()
         self._update_world_task = asyncio.create_task(self._update_world())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_world_task.cancel()
 
     def iso_tile_to_uv(self, y, x):
         h, w = TILE_SIZE

--- a/examples/advanced/labyrinth.py
+++ b/examples/advanced/labyrinth.py
@@ -29,11 +29,11 @@ def _path_yx(a, b):
 
 class Labyrinth(GraphicWidget):
     def on_add(self):
-        super().on_add()
-        self._player_task = asyncio.create_task(self._update_player())
         self._new_level_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+        self._player_task = asyncio.create_task(self._update_player())
         self._reconfigure_task = asyncio.create_task(self._step_reconfigure())
         self.on_size()
+        super().on_add()
 
     def on_remove(self):
         super().on_remove()
@@ -143,4 +143,4 @@ class Labyrinth(GraphicWidget):
         return True
 
 
-run_widget_as_app(Labyrinth, size_hint=(1.0, 1.0))
+run_widget_as_app(Labyrinth(size_hint=(1.0, 1.0)))

--- a/examples/advanced/labyrinth.py
+++ b/examples/advanced/labyrinth.py
@@ -28,13 +28,18 @@ def _path_yx(a, b):
 
 
 class Labyrinth(GraphicWidget):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
+    def on_add(self):
+        super().on_add()
         self._player_task = asyncio.create_task(self._update_player())
         self._new_level_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
         self._reconfigure_task = asyncio.create_task(self._step_reconfigure())
         self.on_size()
+
+    def on_remove(self):
+        super().on_remove()
+        self._player_task.cancel()
+        self._new_level_task.cancel()
+        self._reconfigure_task.cancel()
 
     def on_size(self):
         h, w = self._size

--- a/examples/advanced/minesweeper/minesweeper/__main__.py
+++ b/examples/advanced/minesweeper/minesweeper/__main__.py
@@ -2,4 +2,4 @@ from nurses_2.app import run_widget_as_app
 
 from .minesweeper import MineSweeper
 
-run_widget_as_app(MineSweeper)
+run_widget_as_app(MineSweeper())

--- a/examples/advanced/minesweeper/minesweeper/minesweeper.py
+++ b/examples/advanced/minesweeper/minesweeper/minesweeper.py
@@ -68,11 +68,16 @@ class MineSweeper(Widget):
             pos_hint=(None, .5),
         )
 
-        self._timer_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
-
         self.add_widgets(self.mines_left, self.timer, self.reset_button)
 
+    def on_add(self):
+        super().on_add()
+        self._timer_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
         self.reset()
+
+    def on_remove(self):
+        super().on_remove()
+        self._timer_task.cancel()
 
     @property
     def mines(self):

--- a/examples/advanced/navier_stokes.py
+++ b/examples/advanced/navier_stokes.py
@@ -108,4 +108,4 @@ class Fluid(GraphicWidget):
             await asyncio.sleep(0)
 
 
-run_widget_as_app(Fluid, size_hint=(1.0, 1.0))
+run_widget_as_app(Fluid(size_hint=(1.0, 1.0)))

--- a/examples/advanced/navier_stokes.py
+++ b/examples/advanced/navier_stokes.py
@@ -51,10 +51,14 @@ def sigmoid(array):
 
 
 class Fluid(GraphicWidget):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def on_add(self):
+        super().on_add()
         self.on_size()
         self._update_task = asyncio.create_task(self._update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def on_size(self):
         h, w = self._size

--- a/examples/advanced/pong.py
+++ b/examples/advanced/pong.py
@@ -46,7 +46,14 @@ class Ball(Widget):
         self.left_label = left_label
         self.right_label = right_label
         self.left_score = self.right_score = 0
-        asyncio.create_task(self.update())
+
+    def on_add(self):
+        super().on_add()
+        self._update_task = asyncio.create_task(self.update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def reset(self):
         self.y_pos = FIELD_HEIGHT / 2

--- a/examples/advanced/rubiks/rubiks/rubiks_cube.py
+++ b/examples/advanced/rubiks/rubiks/rubiks_cube.py
@@ -42,7 +42,13 @@ class RubiksCube(GrabbableBehavior, GraphicWidget):
         self._selected_row = self._selected_axis = 0
         self._select()
 
+    def on_add(self):
+        super().on_add()
         self._rotate_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+
+    def on_remove(self):
+        super().on_remove()
+        self._rotate_task.cancel()
 
     def _unselect(self):
         for cube in self.selected_cubes:

--- a/examples/advanced/sandbox/sandbox/__main__.py
+++ b/examples/advanced/sandbox/sandbox/__main__.py
@@ -1,5 +1,6 @@
 from nurses_2.app import run_widget_as_app
+
 from .sandbox import Sandbox
 
 
-run_widget_as_app(Sandbox, size=(31, 100))
+run_widget_as_app(Sandbox(size=(31, 100)))

--- a/examples/advanced/sandbox/sandbox/particles.py
+++ b/examples/advanced/sandbox/sandbox/particles.py
@@ -81,13 +81,7 @@ class Element(ABC):
 
         self.inactivity = 0
 
-    def on_add(self):
-        super().on_add()
         self._update_task = asyncio.create_task(self.update())
-
-    def on_remove(self):
-        super().on_remove()
-        self._update_task.cancel()
 
     def sleep(self):
         """

--- a/examples/advanced/sandbox/sandbox/particles.py
+++ b/examples/advanced/sandbox/sandbox/particles.py
@@ -78,8 +78,16 @@ class Element(ABC):
         self.pos = pos
 
         self.world[pos] = self
-        self._update_task = asyncio.create_task(self.update())
+
         self.inactivity = 0
+
+    def on_add(self):
+        super().on_add()
+        self._update_task = asyncio.create_task(self.update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def sleep(self):
         """

--- a/examples/advanced/sandbox/sandbox/sandbox.py
+++ b/examples/advanced/sandbox/sandbox/sandbox.py
@@ -25,13 +25,14 @@ class Sandbox(GraphicWidget):
     def __init__(self, size: Size):
         super().__init__(size=size, anchor=Anchor.CENTER, pos_hint=(.5, .5), default_color=ABLACK)
 
+    def on_add(self):
+        super().on_add()
         # Build array of particles -- Initially all Air
         self.world = world = np.full((2 * self.height, self.width), None, dtype=object)
         for y in range(2 * self.height):
             for x in range(self.width):
                 world[y, x] = Air(world, (y, x))
 
-        # Add children widgets
         self.display = TextWidget(
             size=(1, 9),
             pos=(1, 0),
@@ -43,6 +44,11 @@ class Sandbox(GraphicWidget):
 
         # Press the Stone button setting particle type.
         self.children[1].children[1].on_release()
+
+    def on_remove(self):
+        super().on_remove()
+        for particle in self.world.flatten():
+            particle.sleep()
 
     def render(self, canvas_view, colors_view, source: tuple[slice, slice]):
         # Color of each particle in `self.world` is written into color array.

--- a/examples/advanced/shadow_casting.py
+++ b/examples/advanced/shadow_casting.py
@@ -116,12 +116,13 @@ class MyShadowCaster(ShadowCaster):
 
 
 run_widget_as_app(
-    MyShadowCaster,
-    size_hint=(1.0, 1.0),
-    map=MAP,
-    camera=Camera((0, 0), (50, 50)),
-    tile_colors=[AGRAY, ACYAN, AMAGENTA],
-    light_sources=[LightSource()],
-    ambient_light=.1,
-    radius=40,
+    MyShadowCaster(
+        size_hint=(1.0, 1.0),
+        map=MAP,
+        camera=Camera((0, 0), (50, 50)),
+        tile_colors=[AGRAY, ACYAN, AMAGENTA],
+        light_sources=[LightSource()],
+        ambient_light=.1,
+        radius=40,
+    )
 )

--- a/examples/advanced/shadow_casting.py
+++ b/examples/advanced/shadow_casting.py
@@ -76,9 +76,13 @@ WHITE_TO_BLUE = cycle(map(
 
 
 class MyShadowCaster(ShadowCaster):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def on_add(self):
+        super().on_add()
         self._update_task = asyncio.create_task(self._update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     async def _update(self):
         while True:

--- a/examples/advanced/snake.py
+++ b/examples/advanced/snake.py
@@ -30,11 +30,16 @@ def inbounds(pos):
 
 
 class Snake(GraphicWidget):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def on_add(self):
+        super().on_add()
         self.reset()
         self._update_task = asyncio.create_task(self._update())
         self._apple_task = asyncio.create_task(self._paint_apple())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
+        self._apple_task.cancel()
 
     def on_size(self):
         super().on_size()

--- a/examples/advanced/sph/sph/__main__.py
+++ b/examples/advanced/sph/sph/__main__.py
@@ -21,7 +21,14 @@ class SPH(GraphicWidget):
         super().__init__(is_transparent=is_transparent, **kwargs)
         y, x = self.size
         self.sph_solver = SPHSolver(nparticles, (2 * y, x))
+
+    def on_add(self):
+        super().on_add()
         self._update_task = asyncio.create_task(self._update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def on_keypress(self, key_press_event):
         match key_press_event.key:

--- a/examples/advanced/stable_fluid.py
+++ b/examples/advanced/stable_fluid.py
@@ -36,8 +36,15 @@ EPSILON = np.finfo(float).eps
 class StableFluid(GraphicWidget):
     def __init__(self, default_color=ABLACK, **kwargs):
         super().__init__(default_color=default_color, **kwargs)
+
+    def on_add(self):
+        super().on_add()
         self.on_size()
         self._update_task = asyncio.create_task(self._update())
+
+    def on_remove(self):
+        super().on_remove()
+        self._update_task.cancel()
 
     def on_size(self):
         h, w = self._size

--- a/examples/advanced/stable_fluid.py
+++ b/examples/advanced/stable_fluid.py
@@ -153,4 +153,4 @@ class StableFluid(GraphicWidget):
             await asyncio.sleep(0)
 
 
-run_widget_as_app(StableFluid, size_hint=(1.0, 1.0))
+run_widget_as_app(StableFluid(size_hint=(1.0, 1.0)))

--- a/examples/advanced/tetris/tetris/matrix.py
+++ b/examples/advanced/tetris/tetris/matrix.py
@@ -10,10 +10,14 @@ class LevelGlowEffect(Effect):
     """
     Apply a glow effect that quickens as levels increase.
     """
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def on_add(self):
+        super().on_add()
         self._glow = 0
-        asyncio.create_task(self.glow())
+        self._glow_task = asyncio.create_task(self.glow())
+
+    def on_remove(self):
+        super().on_remove()
+        self._glow_task.cancel()
 
     async def glow(self):
         while self.parent is None:

--- a/examples/advanced/tetris/tetris/modal_screen.py
+++ b/examples/advanced/tetris/tetris/modal_screen.py
@@ -79,7 +79,15 @@ class ModalScreen(TextWidget):
         for i, color in enumerate(GRADIENT):
             self.colors[i, :] = color
 
+    def on_add(self):
+        super().on_add()
         self._countdown_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+        self._line_glow_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+
+    def on_remove(self):
+        super().on_remove()
+        self._countdown_task.cancel()
+        self._line_glow_task.cancel()
 
     def on_keypress(self, key_press_event):
         if self._countdown_task.done():
@@ -89,11 +97,6 @@ class ModalScreen(TextWidget):
 
     def enable(self, callback, is_game_over):
         self.callback = callback
-
-        if self.parent is not self.root:
-            root = self.root
-            self.parent.remove_widget(self)
-            root.add_widget(self)
 
         for i, line in enumerate(GAME_OVER if is_game_over else PAUSED, start=1):
             self.add_text(line, row=i)

--- a/examples/advanced/tetris/tetris/tetris.py
+++ b/examples/advanced/tetris/tetris/tetris.py
@@ -89,10 +89,6 @@ class Tetris(Image):
         )
         self.tetromino_generator = tetromino_generator(ARIKA_TETROMINOS if arika else TETROMINOS)
         self._level = 0
-        self._game_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
-        self._lock_down_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
-        self._clear_lines_queue = deque()
-
         self.is_paused = False
 
         # Setup HELD display
@@ -159,7 +155,21 @@ class Tetris(Image):
         self.add_widget(self.matrix_widget)
 
         self.modal_screen = ModalScreen()
-        self.add_widget(self.modal_screen)
+
+    def on_add(self):
+        super().on_add()
+        self.root.add_widget(self.modal_screen)
+        self._game_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+        self._lock_down_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
+        self._clear_lines_queue = deque()
+
+    def on_remove(self):
+        super().on_remove()
+        self.root.remove_widget(self.modal_screen)
+        self._game_task.cancel()
+        self._lock_down_task.cancel()
+        for task in self._clear_lines_queue:
+            task.cancel()
 
     def on_size(self):
         super().on_size()

--- a/examples/basic/braille_image.py
+++ b/examples/basic/braille_image.py
@@ -6,4 +6,4 @@ from nurses_2.widgets.braille_image import BrailleImage
 ASSETS = Path(__file__).parent.parent / "assets"
 PATH_TO_IMAGE = ASSETS / "loudypixelsky.png"
 
-run_widget_as_app(BrailleImage, path=PATH_TO_IMAGE, size_hint=(1.0, 1.0))
+run_widget_as_app(BrailleImage(path=PATH_TO_IMAGE, size_hint=(1.0, 1.0)))

--- a/examples/basic/buttons.py
+++ b/examples/basic/buttons.py
@@ -10,26 +10,15 @@ from nurses_2.widgets.toggle_button import ToggleButton, ToggleState
 class MyApp(App):
     async def on_start(self):
         display = TextWidget(size=(1, 20), pos=(1, 9))
-        display._clear_task = asyncio.create_task(asyncio.sleep(0))  # dummy task
-
-        async def clear_display():
-            await asyncio.sleep(3)
-            display.canvas[:] = " "
 
         def button_callback(i):
             def callback():
                 display.add_text(f"Button {i + 1} pressed!".ljust(20))
-                display._clear_task.cancel()
-                display._clear_task = asyncio.create_task(clear_display())
-
             return callback
 
         def toggle_button_callback(i):
             def callback(state):
                 display.add_text(f"Button {i + 1} {'un' if state is ToggleState.OFF else ''}toggled!".ljust(20))
-                display._clear_task.cancel()
-                display._clear_task = asyncio.create_task(clear_display())
-
             return callback
 
         grid_layout = GridLayout(

--- a/examples/basic/color_picker.py
+++ b/examples/basic/color_picker.py
@@ -1,4 +1,4 @@
 from nurses_2.app import run_widget_as_app
 from nurses_2.widgets.color_picker import ColorPicker
 
-run_widget_as_app(ColorPicker, size_hint=(1.0, 1.0))
+run_widget_as_app(ColorPicker(size_hint=(1.0, 1.0)))

--- a/examples/basic/io_events.py
+++ b/examples/basic/io_events.py
@@ -37,8 +37,8 @@ class ShowIOEvents(TextWidget):
                     position: {}
                     type: {}
                     button: {}
-                    nclicks: {}
                     mods: {}
+                    nclicks: {}
                 """
             case PasteEvent():
                 text = "\nGot paste event:\n{}"
@@ -48,4 +48,4 @@ class ShowIOEvents(TextWidget):
             self.add_text(line.ljust(self.width)[:self.width], row=i)
 
 
-run_widget_as_app(ShowIOEvents, size_hint=(1.0, 1.0))
+run_widget_as_app(ShowIOEvents(size_hint=(1.0, 1.0)))

--- a/examples/basic/line_plot.py
+++ b/examples/basic/line_plot.py
@@ -14,16 +14,14 @@ YS_2 = np.random.randint(0, 100, 20)
 YS_3 = np.random.randint(0, 100, 20)
 
 run_widget_as_app(
-    LinePlot,
-    XS,
-    YS_1,
-    XS,
-    YS_2,
-    XS,
-    YS_3,
-    xlabel="X Values",
-    ylabel="Y Values",
-    legend_labels=("Before", "During", "After"),
-    size_hint=(1.0, 1.0),
-    background_color_pair=ColorPair.from_colors(LIGHT_BLUE, DARK_PURPLE),
+    LinePlot(
+        XS, YS_1,
+        XS, YS_2,
+        XS, YS_3,
+        xlabel="X Values",
+        ylabel="Y Values",
+        legend_labels=("Before", "During", "After"),
+        size_hint=(1.0, 1.0),
+        background_color_pair=ColorPair.from_colors(LIGHT_BLUE, DARK_PURPLE),
+    )
 )

--- a/examples/basic/parallax.py
+++ b/examples/basic/parallax.py
@@ -22,9 +22,9 @@ class MyApp(App):
             while True:
                 for theta in angles:
                     parallax.offset = radius * np.cos(theta), radius * np.sin(theta)
-                    await asyncio.sleep(.016)
+                    await asyncio.sleep(0)
 
-        asyncio.create_task(circle_movement())
+        await circle_movement()
 
 
 MyApp(title="Parallax Example").run()

--- a/examples/basic/scroll_view.py
+++ b/examples/basic/scroll_view.py
@@ -27,7 +27,7 @@ class MyApp(App):
             big_widget.colors[y] = gradient(LEFT_GRADIENT[y], RIGHT_GRADIENT[y], BIG_WIDGET_SIZE.columns)
 
         scroll_view = ScrollView(size=(10, 30), anchor=Anchor.CENTER, pos_hint=(0.5, 0.5))
-        scroll_view.add_widget(big_widget)
+        scroll_view.view = big_widget
 
         self.add_widget(scroll_view)
 

--- a/examples/basic/windows.py
+++ b/examples/basic/windows.py
@@ -25,30 +25,29 @@ YS_3 = np.random.randint(0, 100, 20)
 
 class MyApp(App):
     async def on_start(self):
-        animation = Animation(size_hint=(1.0, 1.0), path=CAVEMAN_PATH, interpolation=Interpolation.NEAREST)
-        animation.play()
-        window_1 = Window(size=(25, 50), alpha=.7, title=CAVEMAN_PATH.name)
-        window_1.add_widget(animation)
+        window_kwargs = dict(size=(25, 50), border_alpha=.7, alpha=.7)
 
-        window_2 = Window(size=(25, 50), alpha=.7, title="File Chooser")
-        window_2.add_widget(FileChooser(root_dir=ASSETS, size_hint=(1.0, 1.0)))
+        animation = Animation(path=CAVEMAN_PATH, interpolation=Interpolation.NEAREST)
+        window_1 = Window(title=CAVEMAN_PATH.name, **window_kwargs)
+        window_1.view = animation
 
-        window_3 = Window(size=(25, 50), alpha=.7, title="Color Picker")
-        window_3.add_widget(ColorPicker(size_hint=(1.0, 1.0)))
+        window_2 = Window(title="File Chooser", **window_kwargs)
+        window_2.view = FileChooser(root_dir=ASSETS)
 
-        window_4 = Window(size=(25, 50), alpha=.7, title="Line Plot")
-        window_4.add_widget(
-            LinePlot(
-                XS, YS_1, XS, YS_2, XS, YS_3,
-                xlabel="X Values",
-                ylabel="Y Values",
-                legend_labels=("Before", "During", "After"),
-                size_hint=(1.0, 1.0),
-                background_color_pair=ColorPair.from_colors(LIGHT_BLUE, DARK_PURPLE),
-            )
+        window_3 = Window(title="Color Picker", **window_kwargs)
+        window_3.view = ColorPicker()
+
+        window_4 = Window(title="Line Plot", **window_kwargs)
+        window_4.view = LinePlot(
+            XS, YS_1, XS, YS_2, XS, YS_3,
+            xlabel="X Values",
+            ylabel="Y Values",
+            legend_labels=("Before", "During", "After"),
+            background_color_pair=ColorPair.from_colors(LIGHT_BLUE, DARK_PURPLE),
         )
 
         self.add_widgets(window_1, window_2, window_3, window_4)
+        animation.play()
 
 
 MyApp(title="Windows Example").run()

--- a/nurses_2/__init__.py
+++ b/nurses_2/__init__.py
@@ -4,4 +4,4 @@ nurses_2
 
 A widgetful and async-centric terminal graphics library.
 """
-__version__ = "0.11.7"
+__version__ = "0.12"

--- a/nurses_2/app.py
+++ b/nurses_2/app.py
@@ -245,23 +245,17 @@ class App(ABC):
         return self.root.children
 
 
-def run_widget_as_app(widget: type[Widget], *args, **kwargs):
+def run_widget_as_app(widget: Widget):
     """
     Run a widget as a full-screen app.
 
     Parameters
     ----------
-    widget : type[Widget]
-        Widget type to be instantiated and run as an app.
-
-    *args
-        Positional arguments for widget instantiation.
-
-    **kwargs
-        Keyword arguments for widget instantiation.
+    widget : Widget
+        A widget to run as a full screen app.
     """
     class _DefaultApp(App):
         async def on_start(self):
-            self.add_widget(widget(*args, **kwargs))
+            self.add_widget(widget)
 
-    _DefaultApp(title=widget.__name__).run()
+    _DefaultApp(title=type(widget).__name__).run()

--- a/nurses_2/app.py
+++ b/nurses_2/app.py
@@ -144,6 +144,7 @@ class App(ABC):
         """
         Exit the app.
         """
+        self.root.destroy()
         for task in asyncio.all_tasks():
             task.cancel()
 

--- a/nurses_2/colors/colors.py
+++ b/nurses_2/colors/colors.py
@@ -88,7 +88,7 @@ DEFAULT_COLOR_THEME = ColorTheme(
     primary_bg=Color.from_hex("#311b92"),
 
     primary_fg_dark=Color.from_hex("#b39ddb"),
-    primary_bg_dark=Color.from_hex("#000063"),
+    primary_bg_dark=Color.from_hex("#29177a"),
 
     primary_fg_light=Color.from_hex("#ede7f6"),
     primary_bg_light=Color.from_hex("#6746c3"),

--- a/nurses_2/widgets/behaviors/grab_resize_behavior.py
+++ b/nurses_2/widgets/behaviors/grab_resize_behavior.py
@@ -3,6 +3,7 @@ Draggable resize behavior for a widget.
 """
 from ...clamp import clamp
 from ..graphic_widget import GraphicWidget, Size, AColor, TRANSPARENT
+from ..widget import emitter
 from .grabbable_behavior import GrabbableBehavior
 
 __all__ = "GrabResizeBehavior",
@@ -168,6 +169,7 @@ class GrabResizeBehavior:
         return self._border_size
 
     @border_size.setter
+    @emitter
     def border_size(self, size: Size):
         h, w = size
         self._border_size = Size(clamp(h, 1, None), clamp(w, 1, None))

--- a/nurses_2/widgets/braille_image.py
+++ b/nurses_2/widgets/braille_image.py
@@ -189,6 +189,14 @@ class BrailleImage(TextWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, *, path: Path, **kwargs):
         super().__init__(**kwargs)

--- a/nurses_2/widgets/button.py
+++ b/nurses_2/widgets/button.py
@@ -186,6 +186,14 @@ class Button(Themable, ButtonBehavior, Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/color_picker.py
+++ b/nurses_2/widgets/color_picker.py
@@ -299,6 +299,14 @@ class ColorPicker(Themable, Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/digital_display.py
+++ b/nurses_2/widgets/digital_display.py
@@ -348,6 +348,14 @@ class DigitalDisplay(TextWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     a  = _Segment(np.s_[0, 1: 6])
     b  = _Segment(np.s_[1: 3, 6])

--- a/nurses_2/widgets/file_chooser.py
+++ b/nurses_2/widgets/file_chooser.py
@@ -252,6 +252,14 @@ class FileViewNode(TreeViewNode):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, path: Path, **kwargs):
         self.path = path
@@ -467,6 +475,14 @@ class FileView(TreeView):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,
@@ -793,6 +809,14 @@ class FileChooser(Themable, ScrollView):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/file_chooser.py
+++ b/nurses_2/widgets/file_chooser.py
@@ -829,13 +829,11 @@ class FileChooser(Themable, ScrollView):
         kwargs.pop("arrow_keys_enabled", None)
         super().__init__(arrow_keys_enabled=False, **kwargs)
 
-        self.add_widget(
-            FileView(
-                root_node=FileViewNode(path=root_dir or Path()),
-                directories_only=directories_only,
-                show_hidden=show_hidden,
-                select_callback=select_callback,
-            )
+        self.view = FileView(
+            root_node=FileViewNode(path=root_dir or Path()),
+            directories_only=directories_only,
+            show_hidden=show_hidden,
+            select_callback=select_callback,
         )
         self._view.update_tree_layout()
         self.update_theme()

--- a/nurses_2/widgets/graphic_widget.py
+++ b/nurses_2/widgets/graphic_widget.py
@@ -197,6 +197,14 @@ class GraphicWidget(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/grid_layout.py
+++ b/nurses_2/widgets/grid_layout.py
@@ -243,6 +243,14 @@ class GridLayout(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
 
     Raises
     ------

--- a/nurses_2/widgets/image.py
+++ b/nurses_2/widgets/image.py
@@ -187,6 +187,14 @@ class Image(GraphicWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, *, path: Path | None=None, **kwargs):
         self._otexture = np.zeros((2, 1, 4), dtype=np.uint8)

--- a/nurses_2/widgets/line_plot/line_plot.py
+++ b/nurses_2/widgets/line_plot/line_plot.py
@@ -185,6 +185,14 @@ class LinePlot(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/line_plot/line_plot.py
+++ b/nurses_2/widgets/line_plot/line_plot.py
@@ -240,7 +240,7 @@ class LinePlot(Widget):
             show_horizontal_bar=False,
             scrollwheel_enabled=False,
         )
-        self._scrollview.add_widget(self._traces)
+        self._scrollview.view = self._traces
 
         self._tick_corner = TextWidget(
             size=(2, TICK_WIDTH),

--- a/nurses_2/widgets/menu.py
+++ b/nurses_2/widgets/menu.py
@@ -247,6 +247,14 @@ class MenuItem(Themable, ToggleButtonBehavior, Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,
@@ -581,6 +589,14 @@ class Menu(GridLayout):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/parallax.py
+++ b/nurses_2/widgets/parallax.py
@@ -205,6 +205,14 @@ class Parallax(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/particle_field/graphic_field.py
+++ b/nurses_2/widgets/particle_field/graphic_field.py
@@ -226,6 +226,14 @@ class GraphicParticleField(_ParticleFieldBase):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     _child_type = GraphicParticle
 

--- a/nurses_2/widgets/particle_field/text_field.py
+++ b/nurses_2/widgets/particle_field/text_field.py
@@ -230,6 +230,14 @@ class TextParticleField(_ParticleFieldBase):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     _child_type = TextParticle
 

--- a/nurses_2/widgets/progress_bar.py
+++ b/nurses_2/widgets/progress_bar.py
@@ -200,6 +200,14 @@ class ProgressBar(Themable, TextWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, is_horizontal: bool=True, **kwargs):
         super().__init__(**kwargs)

--- a/nurses_2/widgets/ray_caster/ray_caster.py
+++ b/nurses_2/widgets/ray_caster/ray_caster.py
@@ -218,6 +218,14 @@ class RayCaster(GraphicWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     HOPS = 20  # How far rays are cast.
 

--- a/nurses_2/widgets/scroll_view/scroll_view.py
+++ b/nurses_2/widgets/scroll_view/scroll_view.py
@@ -219,6 +219,14 @@ class ScrollView(GrabbableBehavior, Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
 
     Raises
     ------

--- a/nurses_2/widgets/scroll_view/scroll_view.py
+++ b/nurses_2/widgets/scroll_view/scroll_view.py
@@ -10,8 +10,9 @@ from .scrollbars import _HorizontalBar, _VerticalBar
 
 class ScrollView(GrabbableBehavior, Widget):
     """
-    A scrollable view widget. A scroll view accepts only one child and
-    places it in a scrollable viewport.
+    A scrollable view widget.
+
+    The view can be set with the :attr:`view` property, e.g., ``my_scrollview.view = some_widget``.
 
     Parameters
     ----------
@@ -76,6 +77,8 @@ class ScrollView(GrabbableBehavior, Widget):
 
     Attributes
     ----------
+    view : Widget | None
+        The scrolled widget.
     allow_vertical_scroll : bool
         Allow vertical scrolling.
     allow_horizontal_scroll : bool
@@ -227,11 +230,6 @@ class ScrollView(GrabbableBehavior, Widget):
         Recursively remove all children.
     destroy:
         Destroy this widget and all descendents.
-
-    Raises
-    ------
-    ValueError
-        If `add_widget` is called while already containing a child.
     """
     def __init__(
         self,
@@ -258,14 +256,7 @@ class ScrollView(GrabbableBehavior, Widget):
         self._vertical_bar = _VerticalBar(is_enabled=show_vertical_bar)
         self._horizontal_bar = _HorizontalBar(is_enabled=show_horizontal_bar)
 
-        self.children = [self._vertical_bar, self._horizontal_bar]
-
-        self._vertical_bar.parent = self
-        self._vertical_bar.update_geometry()
-
-        self._horizontal_bar.parent = self
-        self._horizontal_bar.update_geometry()
-
+        self.add_widgets(self._vertical_bar, self._horizontal_bar)
 
     @property
     def show_vertical_bar(self) -> bool:
@@ -362,25 +353,30 @@ class ScrollView(GrabbableBehavior, Widget):
         self._set_view_top()
         self._set_view_left()
 
-    def add_widget(self, widget):
+    @property
+    def view(self) -> Widget | None:
+        return self._view
+
+    @view.setter
+    def view(self, view: Widget | None):
         if self._view is not None:
-            raise ValueError("View already set.")
+            self.remove_widget(self._view)
 
-        self._view = widget
-        widget.parent = self
-        self.children.insert(0, widget)
-        self.subscribe(widget, "size", self._set_view_pos)
+        self._view = view
 
-        self._set_view_pos()
+        if view is not None:
+            self.add_widget(view)
 
-    def remove_widget(self, widget):
-        if widget is not self._view:
-            raise ValueError(f"{widget} is not view.")
+            self.children.insert(0, self.children.pop())  # Move view to top of view stack.
+            self.subscribe(view, "size", self._set_view_pos)
+            self._set_view_pos()
 
-        self._view = None
-        widget.parent = None
-        self.children.remove(widget)
-        self.unsubscribe(widget, "size")
+    def remove_widget(self, widget: Widget):
+        if widget is self._view:
+            self._view = None
+            self.unsubscribe(widget, "size")
+
+        super().remove_widget(widget)
 
     def on_size(self):
         if self._view is not None:

--- a/nurses_2/widgets/shadow_caster/shadow_caster.py
+++ b/nurses_2/widgets/shadow_caster/shadow_caster.py
@@ -238,6 +238,14 @@ class ShadowCaster(GraphicWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/slider/slider.py
+++ b/nurses_2/widgets/slider/slider.py
@@ -217,6 +217,14 @@ class Slider(TextWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/split_layout.py
+++ b/nurses_2/widgets/split_layout.py
@@ -223,6 +223,14 @@ class HSplitLayout(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,
@@ -484,6 +492,14 @@ class VSplitLayout(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/text_widget.py
+++ b/nurses_2/widgets/text_widget.py
@@ -198,6 +198,14 @@ class TextWidget(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/tiled_image.py
+++ b/nurses_2/widgets/tiled_image.py
@@ -180,6 +180,14 @@ class TiledImage(GraphicWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, *, tile: GraphicWidget, **kwargs):
         super().__init__(**kwargs)

--- a/nurses_2/widgets/toggle_button.py
+++ b/nurses_2/widgets/toggle_button.py
@@ -213,6 +213,14 @@ class ToggleButton(Themable, ToggleButtonBehavior, Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(
         self,

--- a/nurses_2/widgets/tree_view.py
+++ b/nurses_2/widgets/tree_view.py
@@ -225,6 +225,14 @@ class TreeViewNode(Themable, ButtonBehavior, TextWidget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, is_leaf=True, **kwargs):
         self.is_leaf = is_leaf
@@ -500,6 +508,14 @@ class TreeView(Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
     """
     def __init__(self, root_node: TreeViewNode, **kwargs):
         self.selected_node = None

--- a/nurses_2/widgets/window.py
+++ b/nurses_2/widgets/window.py
@@ -194,6 +194,14 @@ class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
         Handle paste event.
     tween:
         Sequentially update a widget property over time.
+    on_add:
+        Called when widget is added to widget tree.
+    on_remove:
+        Called when widget is removed from widget tree.
+    prolicide:
+        Recursively remove all children.
+    destroy:
+        Destroy this widget and all descendents.
 
     Notes
     -----

--- a/nurses_2/widgets/window.py
+++ b/nurses_2/widgets/window.py
@@ -1,24 +1,24 @@
 """
 A movable, resizable window widget.
 """
+import numpy as np
 from wcwidth import wcswidth
 
-from ..clamp import clamp
 from ..colors import ColorPair, AColor
 from .behaviors.focus_behavior import FocusBehavior
 from .behaviors.grabbable_behavior import GrabbableBehavior
 from .behaviors.grab_resize_behavior import GrabResizeBehavior
 from .behaviors.themable import Themable
-from .graphic_widget import GraphicWidget
 from .text_widget import TextWidget
-from .widget import Widget, Size, Anchor
+from .graphic_widget import GraphicWidget
+from .widget import Widget, Anchor
 
 __all__ = "Window",
 
 
-class _TitleBar(GrabbableBehavior, TextWidget):
-    def __init__(self, **kwargs):
-        super().__init__(disable_ptf=True, **kwargs)
+class _TitleBar(GrabbableBehavior, Widget):
+    def __init__(self):
+        super().__init__(disable_ptf=True, is_transparent=False, background_char=" ")
 
         self._label = TextWidget(pos_hint=(None, .5), anchor=Anchor.TOP_CENTER)
         self.add_widget(self._label)
@@ -32,24 +32,41 @@ class _TitleBar(GrabbableBehavior, TextWidget):
         self.size = bh, self.parent.width - 2 * bw
 
 
-class _View(GraphicWidget):
-    def update_geometry(self):
-        h, w = self.parent.size
-        bh, bw = self.parent.border_size
-        self.size = h - 1 - 2 * bh, w - 2 * bw
-        self.is_visible = h > bh * 3 and w > bw * 2
-
-
-class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
+class Window(Themable, FocusBehavior, GrabResizeBehavior, GraphicWidget):
     """
     A movable, resizable window widget.
+
+    The view can be set with the :attr:`view` property, e.g., ``my_window.view = some_widget``.
+
+    Note
+    ----
+    As the window is resized, the :attr:`view` will be resized to fit within the window's borders,
+    but non-`None` size hints of the view are still respected which can have unexpected results.
+    It is recommended to use views with no size hints.
 
     Parameters
     ----------
     title : str, default: ""
         Title of window.
+    ptf_on_focus : bool, default: True
+        Pull widget to front when it gains focus.
+    allow_vertical_resize : bool, default: True
+        Allow vertical resize.
+    allow_horizontal_resize : bool, default: True
+        Allow horizontal resize.
+    border_alpha : float, default: 1.0
+        Transparency of border. This value will be clamped between `0.0` and `1.0`.
+    border_color : AColor, default: TRANSPARENT
+        Color of border.
+    border_size : Size, default: Size(1, 2)
+        Height and width of horizontal and vertical borders, respectively.
+    default_color : AColor, default: AColor(0, 0, 0, 0)
+        Default texture color.
     alpha : float, default: 1.0
-        Transparency of window background and border.
+        If widget is transparent, the alpha channel of the underlying texture will be multiplied by this
+        value. (0 <= alpha <= 1.0)
+    interpolation : Interpolation, default: Interpolation.LINEAR
+        Interpolation used when widget is resized.
     size : Size, default: Size(10, 10)
         Size of widget.
     pos : Point, default: Point(0, 0)
@@ -89,6 +106,30 @@ class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
 
     Attributes
     ----------
+    title : str
+        Title of window.
+    ptf_on_focus : bool, default: True
+        Pull widget to front when it gains focus.
+    is_focused : bool
+        True if widget has focus.
+    allow_vertical_resize : bool
+        Allow vertical resize.
+    allow_horizontal_resize : bool
+        Allow horizontal resize.
+    border_alpha : float
+        Transparency of border. This value will be clamped between `0.0` and `1.0`.
+    border_color : AColor
+        Color of border.
+    border_size : Size
+        Height and width of horizontal and vertical borders, respectively.
+    texture : numpy.ndarray
+        uint8 RGBA color array.
+    default_color : AColor
+        Default texture color.
+    alpha : float
+        Transparency of widget if :attr:`is_transparent` is true.
+    interpolation : Interpolation
+        Interpolation used when widget is resized.
     size : Size
         Size of widget.
     height : int
@@ -160,6 +201,16 @@ class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
 
     Methods
     -------
+    update_theme:
+        Paint the widget with current theme.
+    on_focus:
+        Called when widget is focused.
+    on_blur:
+        Called when widget loses focus.
+    pull_border_to_front:
+        Pull borders to the front.
+    to_png:
+        Write :attr:`texture` to provided path as a `png` image.
     on_size:
         Called when widget is resized.
     update_geometry:
@@ -209,9 +260,7 @@ class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
     set large enough so that the border is visible and the titlebar's
     label is visible.
     """
-    def __init__(self, title="", alpha=1.0, **kwargs):
-        self._view = None
-
+    def __init__(self, title="", **kwargs):
         super().__init__(**kwargs)
 
         if self.min_height is None:
@@ -220,38 +269,59 @@ class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
         if self.min_width is None:
             self.min_width = 1
 
-        self.add_widgets(_View(), _TitleBar())
-        self.pull_border_to_front()
-        self._view = self.children[0]
-        self._titlebar = self.children[1]
+        self._view = None
+        self._titlebar = _TitleBar()
+        self.add_widget(self._titlebar)
 
-        self.alpha = alpha
         self.title = title
 
         self.update_theme()
 
-        self.border_size = self.border_size  # Reposition titlebar and view
+        def on_border_size():
+            h, w = self.border_size
+            self._titlebar.pos = h, w
+
+            if self._view is not None:
+                self._view.pos = h * 2, w
+
+            self.min_height = max(h * 3, self.min_height)
+            self.min_width = max(wcswidth(self._title) + w * 2 + 2, self.min_width)
+
+        self.subscribe(self, "border_size", on_border_size)
+        on_border_size()
 
     @property
-    def border_size(self) -> Size:
-        return self._border_size
+    def view(self) -> Widget | None:
+        return self._view
 
-    @border_size.setter
-    def border_size(self, size: Size):
-        h, w = size
-        self._border_size = Size(clamp(h, 1, None), clamp(w, 1, None))
+    @view.setter
+    def view(self, view: Widget | None):
+        if self._view is not None:
+            self.remove_widget(self._view)
 
-        for border in self._borders:
-            border.update_geometry()
+        self._view = view
 
-        if self._view is None:  # Still being initialized.
-            return
+        if view is not None:
+            h, w = self.border_size
+            view.pos = 2 * h, w
+            self.add_widget(view)
+            self.children.insert(0, self.children.pop())  # Move view to top of view stack.
+            self.on_size()
 
-        self._titlebar.pos = h, w
-        self._view.pos = h * 2, w
+    def on_size(self):
+        h, w = self._size
+        bh, bw = self.border_size
 
-        self.min_height = max(h * 3, self.min_height)
-        self.min_width = max(wcswidth(self._title) + self.border_size.width * 2 + 2, self.min_width)
+        self.texture = np.zeros((2 * h, w, 4), dtype=np.uint8)
+        self.texture[2 * bh: -2 * bh, bw: -bw] = self.default_color
+
+        if self._view is not None:
+            if self._view.size_hint == (None, None):
+                self._view.size = h - 3 * bh, w - 2 * bw
+            elif self._view.height_hint is None:
+                self._view.height = h - 3 * bh
+            elif self._view.width_hint is None:
+                self._view.width = w - 2 * bw
 
     @property
     def title(self):
@@ -264,50 +334,28 @@ class Window(Themable, FocusBehavior, GrabResizeBehavior, Widget):
         self._titlebar._label.add_text(title)
         self.min_width = max(wcswidth(title) + self.border_size.width * 2 + 2, self.min_width)
 
-    @property
-    def alpha(self) -> float:
-        return self._alpha
-
-    @alpha.setter
-    def alpha(self, alpha: float):
-        self._alpha = clamp(alpha, 0.0, 1.0)
-        self.border_alpha = self._view.alpha = self._alpha
-
     def update_theme(self):
         ct = self.color_theme
 
-        view_background = AColor(*ct.primary_bg_light, 255)
-        self._view.default_color = view_background
-        self._view.texture[:] = view_background
+        self.default_color = AColor(*ct.primary_bg)
+        bh, bw = self.border_size
+        self.texture[2 * bh: -2 * bh, bw: -bw] = self.default_color
 
         if self.is_focused:
-            self.border_color = AColor(*ct.secondary_bg, 255)
+            self.border_color = AColor(*ct.primary_bg_light)
         else:
-            self.border_color = AColor(*ct.primary_bg, 255)
+            self.border_color = self.default_color
 
         title_bar_color_pair = ColorPair.from_colors(ct.secondary_bg, ct.primary_bg_dark)
-        self._titlebar.default_color_pair = title_bar_color_pair
-        self._titlebar.colors[:] = title_bar_color_pair
-        self._titlebar._label.default_color_pair = title_bar_color_pair
-        self._titlebar._label.colors[:] = title_bar_color_pair
+        self._titlebar.background_color_pair = ct.primary_dark_color_pair
+        self._titlebar._label.default_color_pair = ct.primary_dark_color_pair
+        self._titlebar._label.colors[:] = ct.primary_dark_color_pair
 
     def on_focus(self):
         self.update_theme()
 
     def on_blur(self):
         self.update_theme()
-
-    def add_widget(self, widget):
-        if self._view is None:  # Still being initialized.
-            super().add_widget(widget)
-        else:
-            self._view.add_widget(widget)
-
-    def remove_widget(self, widget):
-        if self._view is None:  # Still being initialized.
-            super().remove_widget(widget)
-        else:
-            self._view.remove_widget(widget)
 
     def dispatch_click(self, mouse_event):
         return super().dispatch_click(mouse_event) or self.collides_point(mouse_event.position)


### PR DESCRIPTION
`on_add` and `on_remove` methods added.
Widgets that scheduled tasks in `__init__` now schedule tasks in `on_add` instead.
Tasks are canceled in `on_remove`.

Related methods `prolicide` and `destroy` also added.  (To facilitate cleanup in `on_remove`).

`ScrollView` and `Window` refactored so that destroy reaches all widgets.

`run_app_as_widget` refactored to accept widget instances.