### PR TITLE
Text panel split padding

### DIFF
--- a/nurses_2/widgets/text_panel.py
+++ b/nurses_2/widgets/text_panel.py
@@ -19,8 +19,6 @@ class TextPanel(Themable, TextWidget):
     ----------
     text : str, default: ""
         Panel text.
-    padding : int, default: 1
-        Padding around panel text
     padding_y: int, default: 1
         Padding on top and bottom (y axis)
     padding_x: int, default: 1
@@ -70,8 +68,6 @@ class TextPanel(Themable, TextWidget):
     ----------
     text : str, default: ""
         Panel text.
-    padding : int, default: 1
-        Padding around panel text
     padding_y: int, default: 1
         Padding on top and bottom (y axis)
     padding_x: int, default: 1
@@ -214,7 +210,7 @@ class TextPanel(Themable, TextWidget):
     destroy:
         Destroy this widget and all descendents.
     """
-    def __init__(self, *, text: str="", padding: int=1, padding_y: int=1, padding_x: int=1, **kwargs):
+    def __init__(self, *, text: str="", padding_y: int=1, padding_x: int=1, **kwargs):
         super().__init__(**kwargs)
 
         if padding < 0 or padding_y < 0 or padding_x < 0:
@@ -224,20 +220,9 @@ class TextPanel(Themable, TextWidget):
         self.text_container = TextWidget()
         self._panel.add_widget(self.text_container)
         self.add_widget(self._panel)
-        self.padding = padding
-        self.padding_y = padding_y # | Take precedence over `padding`
-        self.padding_x = padding_x # |
-        self.update_padding()
+        self.padding_y = padding_y
+        self.padding_x = padding_x
         self.text = text
-
-    @property
-    def padding(self) -> int:
-        return self._padding
-
-    @padding.setter
-    def padding(self, padding: int):
-        self._padding = padding, padding
-        self.update_padding()
 
     @property
     def padding_y(self) -> int:

--- a/nurses_2/widgets/text_panel.py
+++ b/nurses_2/widgets/text_panel.py
@@ -7,6 +7,8 @@ from .widget import Widget, Size
 # TODO: Set text with limited markdown.
 
 
+Padding = (int, int)
+
 class TextPanel(Themable, TextWidget):
     """
     A widget for static multi-line text.
@@ -19,8 +21,8 @@ class TextPanel(Themable, TextWidget):
     ----------
     text : str, default: ""
         Panel text.
-    padding : int, default: 1
-        Padding around panel text.
+    padding : Padding, default: (1, 1)
+        Padding around panel text (on y and on x).
     default_char : str, default: " "
         Default background character. This should be a single unicode half-width grapheme.
     default_color_pair : ColorPair, default: WHITE_ON_BLACK
@@ -66,8 +68,8 @@ class TextPanel(Themable, TextWidget):
     ----------
     text : str, default: ""
         Panel text.
-    padding : int, default: 1
-        Padding around panel text.
+    padding : Padding, default: (1, 1)
+        Padding around panel text (on y and on x).
     min_size : Size
         Minimum size needed to show all text.
     text_container : TextWidget
@@ -206,7 +208,7 @@ class TextPanel(Themable, TextWidget):
     destroy:
         Destroy this widget and all descendents.
     """
-    def __init__(self, *, text: str="", padding: int=1, **kwargs):
+    def __init__(self, *, text: str="", padding: Padding=(1, 1), **kwargs):
         super().__init__(**kwargs)
         self._panel = Widget()
         self.text_container = TextWidget()
@@ -220,11 +222,11 @@ class TextPanel(Themable, TextWidget):
         return self._padding
 
     @padding.setter
-    def padding(self, padding: int):
+    def padding(self, padding: Padding):
         self._padding = padding
         h, w = self.size
-        self._panel.size = h - 2 * padding, w - 2 * padding
-        self._panel.pos = padding, padding
+        self._panel.size = h - 2 * padding[0], w - 2 * padding[1]
+        self._panel.pos = padding[0], padding[1]
 
     @property
     def text(self) -> str:
@@ -245,13 +247,13 @@ class TextPanel(Themable, TextWidget):
         """
         pad = self._padding
         h, w = self.text_container.size
-        return Size(h + 2 * pad, w + 2 * pad)
+        return Size(h + 2 * pad[0], w + 2 * pad[1])
 
     def on_size(self):
         super().on_size()
         h, w = self.size
         padding = self._padding
-        self._panel.size = h - 2 * padding, w - 2 * padding
+        self._panel.size = h - 2 * padding[0], w - 2 * padding[1]
 
     def update_theme(self):
         panel = self.color_theme.panel

--- a/nurses_2/widgets/text_panel.py
+++ b/nurses_2/widgets/text_panel.py
@@ -245,9 +245,9 @@ class TextPanel(Themable, TextWidget):
         """
         Minimum size needed for panel to show all text.
         """
-        pad = self._padding
+        padding = self._padding
         h, w = self.text_container.size
-        return Size(h + 2 * pad[0], w + 2 * pad[1])
+        return Size(h + 2 * padding[0], w + 2 * padding[1])
 
     def on_size(self):
         super().on_size()


### PR DESCRIPTION
**Breaking change**
Allows more control over padding for `TextPanel` - now separate for each axis.

There's also a design to make it non-breaking, but that will make it more ugly (adding `padding_y`, `padding_x` as parameters instead if changing `padding` and having 3 of them, which would need to be applied in some non-conflicting way to `self._padding`). But if you think it's worth it, I can tackle with that.
Although, since `TextPanel` was introduced very recently, everyone who started using it probably tries to keep up with changes anyways, so mb we can get away with it.